### PR TITLE
Add a line break to fix Configurator Fixes heading on Issue 6

### DIFF
--- a/_issues/2019-08-05.md
+++ b/_issues/2019-08-05.md
@@ -62,6 +62,7 @@ There has been some more progress on this, lead mostly by zvecr, and a public pr
 - Video tutorial integrated (MechMerlin’s excellent configurator tutorial)
     - Click the wizard hat folks
 - Pretty selector for tester (ISO/ANSI) (Zekuto)
+
 ### Fixes
 - Entering an arbitrarily large number into a momentary layer change key no longer causes the site to crash. - reported by earthbound2eric (yanfali)
 - instant 60 layout rename


### PR DESCRIPTION
GitHub Pages does weird things when you mix list items and headings.

![image](https://user-images.githubusercontent.com/18669334/62497508-098eb880-b791-11e9-8692-6df8e28606d1.png)
